### PR TITLE
Use OpenSSL's `-addext` instead of generating a temp config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A [Certbot](https://certbot.eff.org/) wrapper to process certificate configurati
 # Prerequisites
 1. [Certbot](https://certbot.eff.org/) installed and registered with the CA (`certbot-auto register`)
 2. A webserver with HTTPS support enabled, make sure `.well-known` directory in the document root is accessible and the URLs are not rewritten
+3. OpenSSL 1.1.1 or newer
 
 # Installation
 1. Clone this repository somewhere

--- a/letsgetacert
+++ b/letsgetacert
@@ -258,6 +258,13 @@ function callhook {
 	fi
 }
 
+OPENSSL_VERSION=$(openssl version)
+if echo $OPENSSL_VERSION | awk '$2 !~ /(^0\.)|(^1\.(0\.|1\.0))/ { exit 1 }'; then
+	echo "OpenSSL 1.1.1 or newer is required, yours is $OPENSSL_VERSION"
+	usage
+	exit 4
+fi
+
 parseopts $@
 loadconf
 processconf

--- a/letsgetacert
+++ b/letsgetacert
@@ -115,14 +115,8 @@ function getcert {
 	verbose "[$CN$EXT] subject: $SUBJECT"
 	verbose "[$CN$EXT] alt_names: $ALT_NAMES"
 
-	OPENSSL_CNF_TEMP=$(mktemp --tmpdir tmp.$(basename $0)-cnf.XXXXXXXXXX)
 	CSR_TEMP=$(mktemp --tmpdir tmp.$(basename $0)-csr.XXXXXXXXXX)
-	trap "rm -f $OPENSSL_CNF_TEMP $CSR_TEMP" INT TERM HUP EXIT
-
-	# Generate OpenSSL config file
-	cat /etc/ssl/openssl.cnf > $OPENSSL_CNF_TEMP
-	echo '[ alt_names ]' >> $OPENSSL_CNF_TEMP
-	echo "subjectAltName = $ALT_NAMES" >> $OPENSSL_CNF_TEMP
+	trap "rm -f $CSR_TEMP" INT TERM HUP EXIT
 
 	# Generate key, possibly
 	if [ -n "$PRIVKEY_CMD" ]; then
@@ -135,7 +129,7 @@ function getcert {
 
 	# Generate CSR
 	# Key is owned by root
-	sudo openssl req -new -config $OPENSSL_CNF_TEMP -key $PRIVKEY -outform der -subj "$SUBJECT" -reqexts alt_names > $CSR_TEMP
+	sudo openssl req -new -addext "subjectAltName = $ALT_NAMES" -key $PRIVKEY -outform der -subj "$SUBJECT" > $CSR_TEMP
 
 	# Get the certificate
 	verbose "[$CN$EXT] Calling Certbot $CERTBOT with $CERTBOT_EXTRA_OPTS"


### PR DESCRIPTION
`-addext` is available starting with OpenSSL 1.1.1 which is now a requirement

I think it's safe to require it now as 1.1.1 support [ends soon](https://www.openssl.org/policies/releasestrat.html): _Version 1.1.1 will be supported until 2023-09-11 (LTS)._

Close #2
