### PR TITLE
`CERTBOT_EXTRA_OPTS` & `COMMAND` may also contain multiple words

### DIFF
--- a/letsgetacert
+++ b/letsgetacert
@@ -137,7 +137,8 @@ function getcert {
 
 	# Get the certificate
 	verbose "[$CN$EXT] Calling Certbot $CERTBOT with $CERTBOT_EXTRA_OPTS"
-	$CERTBOT certonly "$CERTBOT_EXTRA_OPTS" --csr "$CSR_TEMP" --cert-path "$CERT" --chain-path "$CHAIN" --fullchain-path "$FULLCHAIN" "$COMMAND"
+	# shellcheck disable=SC2086
+	$CERTBOT certonly $CERTBOT_EXTRA_OPTS --csr "$CSR_TEMP" --cert-path "$CERT" --chain-path "$CHAIN" --fullchain-path "$FULLCHAIN" $COMMAND
 
 	if sudo [ -f "$FULLCHAIN" ]; then
 		verbose "[$CN$EXT] Certificate generated $FULLCHAIN_LIVE -> $FULLCHAIN"


### PR DESCRIPTION
There are some ideas in the ShellCheck docs https://www.shellcheck.net/wiki/SC2086 but they would require changing the config format because CERTBOT_EXTRA_OPTS and CERTBOT_DNS_CHALLENGE_OPTS (used in COMMAND) are loaded from config.

This is the same case as in #12, also broken in #10.